### PR TITLE
Fix SHOW_EXTRA_CMDS, DISABLE_DRIVE_LINK, BotSetCommand

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -238,7 +238,7 @@ help_string = f'''<b><i>㊂ Help Guide :</i></b>
 <b>Bot Settings:</b>
 ➥ /{BotCommands.UserSetCommand[0]} or /{BotCommands.UserSetCommand[1]} [query]: Open User Settings (PM also)
 ➥ /{BotCommands.UsersCommand}: Show User Stats Info (Only Owner & Sudo).
-➥ /{BotCommands.BotSetCommand[0]} or /{BotCommands.BotSetCommand[0]} [query]: Open Bot Settings (Only Owner & Sudo).
+➥ /{BotCommands.BotSetCommand[0]} or /{BotCommands.BotSetCommand[1]} [query]: Open Bot Settings (Only Owner & Sudo).
 
 <b>Authentication:</b>
 ➥ /login: Login to Bot to Access Bot without Temp Pass System (Private)

--- a/bot/helper/listeners/tasks_listener.py
+++ b/bot/helper/listeners/tasks_listener.py
@@ -483,7 +483,7 @@ class MirrorLeechListener:
                 if is_DDL:
                     buttons.ubutton(BotTheme('DDL_LINK', Serv='GoFile'), link)
                 elif link:
-                    if user_id == OWNER_ID or not config_dict['DISABLE_DRIVE_LINK']:
+                    if not config_dict['DISABLE_DRIVE_LINK'] and user_id == OWNER_ID:
                         buttons.ubutton(BotTheme('CLOUD_LINK'), link)
                 else:
                     msg += BotTheme('RCPATH', RCpath=rclonePath)

--- a/bot/helper/telegram_helper/bot_commands.py
+++ b/bot/helper/telegram_helper/bot_commands.py
@@ -12,7 +12,7 @@ class _BotCommands:
             self.QbMirrorCommand.extend([f'qbunzipmirror{CMD_SUFFIX}', f'quzm{CMD_SUFFIX}', f'qbzipmirror{CMD_SUFFIX}', f'qzm{CMD_SUFFIX}'])
         self.YtdlCommand = [f'ytdl{CMD_SUFFIX}', f'y{CMD_SUFFIX}']
         if config_dict['SHOW_EXTRA_CMDS']:
-            self.MirrorCommand.extend([f'ytdlzip{CMD_SUFFIX}', f'yz{CMD_SUFFIX}'])
+            self.YtdlCommand.extend([f'ytdlzip{CMD_SUFFIX}', f'yz{CMD_SUFFIX}'])
         self.LeechCommand = [f'leech{CMD_SUFFIX}', f'l{CMD_SUFFIX}']
         if config_dict['SHOW_EXTRA_CMDS']:
             self.LeechCommand.extend([f'unzipleech{CMD_SUFFIX}', f'uzl{CMD_SUFFIX}', f'zipleech{CMD_SUFFIX}', f'zl{CMD_SUFFIX}'])
@@ -21,7 +21,7 @@ class _BotCommands:
             self.QbLeechCommand.extend([f'qbunzipleech{CMD_SUFFIX}', f'quzl{CMD_SUFFIX}', f'qbzipleech{CMD_SUFFIX}', f'qzl{CMD_SUFFIX}'])
         self.YtdlLeechCommand = [f'ytdlleech{CMD_SUFFIX}', f'yl{CMD_SUFFIX}']
         if config_dict['SHOW_EXTRA_CMDS']:
-            self.MirrorCommand.extend([f'ytdlzipleech{CMD_SUFFIX}', f'yzl{CMD_SUFFIX}'])
+            self.YtdlLeechCommand.extend([f'ytdlzipleech{CMD_SUFFIX}', f'yzl{CMD_SUFFIX}'])
         self.CloneCommand = [f'clone{CMD_SUFFIX}', f'c{CMD_SUFFIX}']
         self.CountCommand = f'count{CMD_SUFFIX}'
         self.DeleteCommand = f'del{CMD_SUFFIX}'


### PR DESCRIPTION
Fix, when set  SHOW_EXTRA_CMDS and SET_COMMANDS to = True not working

DISABLE_DRIVE_LINK = True not working

shows /bsetting or /bs [query]: Open Bot Settings (Only Owner & Sudo).
instead of  /bsetting or /bsetting [query]: Open Bot Settings (Only Owner & Sudo).

Thank You